### PR TITLE
Fix deprecated variable interpolation

### DIFF
--- a/terraform/aws-app-role/main.tf
+++ b/terraform/aws-app-role/main.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "slash-infra-access" {
-  name               = "${var.role_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.allow-slash-infra-account-to-assume.json}"
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.allow-slash-infra-account-to-assume.json
 }
 
 data "aws_iam_policy_document" "allow-slash-infra-account-to-assume" {
@@ -9,15 +9,15 @@ data "aws_iam_policy_document" "allow-slash-infra-account-to-assume" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.trusted_aws_account_arn}"]
+      identifiers = [var.trusted_aws_account_arn]
     }
   }
 }
 
 resource "aws_iam_role_policy" "allow-read-only-access" {
   name   = "allow-read-only-access"
-  role   = "${aws_iam_role.slash-infra-access.id}"
-  policy = "${data.aws_iam_policy_document.allow-read-only-access.json}"
+  role   = aws_iam_role.slash-infra-access.id
+  policy = data.aws_iam_policy_document.allow-read-only-access.json
 }
 
 data "aws_iam_policy_document" "allow-read-only-access" {

--- a/terraform/aws-app-role/outputs.tf
+++ b/terraform/aws-app-role/outputs.tf
@@ -1,4 +1,4 @@
 output "iam_role_arn" {
   description = "The ARN of the IAM role that will be assumed by slash-infra's IAM user. Useful for attaching additional policies to the role that are specific to your org"
-  value       = "${aws_iam_role.slash-infra-access.arn}"
+  value       = aws_iam_role.slash-infra-access.arn
 }

--- a/terraform/aws-app-user/main.tf
+++ b/terraform/aws-app-user/main.tf
@@ -1,10 +1,10 @@
 resource "aws_iam_user" "app-user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_user_policy" "allow-assuming-slash-infra-roles" {
   name = "allow-assuming-slash-infra-roles"
-  user = "${aws_iam_user.app-user.name}"
+  user = aws_iam_user.app-user.name
 
   policy = <<EOF
 {


### PR DESCRIPTION
Terraform 0.12 onwards deprecates the `"${variable.name}"` format in
favour of `variable.name` when not interpolating inside another string
like `"foo-${variable.name}"`.

These result in warnings while running Terraform: 
```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/slash-infra-role/terraform/aws-app-role/main.tf line 2, in resource "aws_iam_role" "slash-infra-access":
   2:   name               = "${var.role_name}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

Related: https://github.com/geckoboard/strata/pull/330