### PR TITLE
Update to be compatible with terraform 0.13 onwards

### DIFF
--- a/terraform/aws-app-role/versions.tf
+++ b/terraform/aws-app-role/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.16"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/terraform/aws-app-user/versions.tf
+++ b/terraform/aws-app-user/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.16"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This change adds the provider declarations that terrraform 0.13 onwards expects

Related PR: https://github.com/geckoboard/strata/pull/453