### PR TITLE
Update AWS provider constraints

### DIFF
--- a/terraform/aws-app-role/versions.tf
+++ b/terraform/aws-app-role/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.16"
+      version = "~> 3.10"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.9"
 }

--- a/terraform/aws-app-user/versions.tf
+++ b/terraform/aws-app-user/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.16"
+      version = "~> 3.10"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.9"
 }


### PR DESCRIPTION
The slash-infra module uses some very old AWS providers which interfere with the version constraint resolution in `strata`, so it's worth upgrading them here. This module seldom gets any attention because it sits outside of `strata` 😢 

```bash
╷
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 3.27.0 does not match configured version
│ constraint ~> 2.16, >= 3.10.0, ~> 3.10; must use terraform init -upgrade to allow selection of new versions
╵
```