### PR TITLE
Bump AWS provider to v4 + bump required TF version

### DIFF
--- a/terraform/aws-app-role/versions.tf
+++ b/terraform/aws-app-role/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.10"
+      version = "~> 4"
     }
   }
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.9"
 }

--- a/terraform/aws-app-role/versions.tf
+++ b/terraform/aws-app-role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4"
+      version = "~> 4.20"
     }
   }
   required_version = ">= 1.1.9"

--- a/terraform/aws-app-user/versions.tf
+++ b/terraform/aws-app-user/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.10"
+      version = "~> 4"
     }
   }
-  required_version = ">= 1.0.9"
+  required_version = ">= 1.1.9"
 }

--- a/terraform/aws-app-user/versions.tf
+++ b/terraform/aws-app-user/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4"
+      version = "~> 4.20"
     }
   }
   required_version = ">= 1.1.9"


### PR DESCRIPTION
Older versions of the AWS provider don't have support for the darwin_arm64 architecture, which makes it difficult to develop against.

The provider version restriction also stops us upgrading the provider in Strata