### PR TITLE
Remove provider version constraints

### DIFF
--- a/terraform/aws-app-role/versions.tf
+++ b/terraform/aws-app-role/versions.tf
@@ -2,8 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.20"
+      version = ">= 4.20"
     }
   }
-  required_version = ">= 1.1.9"
 }

--- a/terraform/aws-app-user/versions.tf
+++ b/terraform/aws-app-user/versions.tf
@@ -1,9 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.20"
+      source = "hashicorp/aws"
     }
   }
-  required_version = ">= 1.1.9"
 }


### PR DESCRIPTION
We don't do anything in these modules which needs a specific version of the AWS provider. I'm trying to upgrade the AWS providers in Strata and the provider constraints here make it a bit tricky.
