### PR TITLE
Remove AWS provider constraint

### DIFF
--- a/terraform/aws-app-role/versions.tf
+++ b/terraform/aws-app-role/versions.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.20"
+      source = "hashicorp/aws"
     }
   }
 }


### PR DESCRIPTION
We don't need this here, really, since we're not using any particularly
unusual resources.
